### PR TITLE
Fix misnamed terminal class

### DIFF
--- a/css/terminal.css
+++ b/css/terminal.css
@@ -55,12 +55,12 @@
     min-height: 150px;
 }
 
-.terminal_promt {
+.terminal_prompt {
     display: flex;
     flex-wrap: wrap;
 }
 
-.terminal_promt span {
+.terminal_prompt span {
     margin-left: 4px;
 }
 

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                 <div class="add_tab">+</div>
             </div>
             <div class="terminal_body">
-                <div class="terminal_promt">
+                <div class="terminal_prompt">
                     <span class="terminal_user">yourname@admin:</span>
                     <span class="terminal_location">~</span>
                     <span class="terminal_bling">$</span>


### PR DESCRIPTION
## Summary
- fix the typo `terminal_promt` -> `terminal_prompt`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d7c45834c832db03f7f678580769d