### PR TITLE
Fix timeline circle alignment

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -109,7 +109,7 @@ h2 {
 /* === Timeline Fix === */
 .timeline {
     position: relative;
-    padding-left: 50px;
+    padding-left: 46px;
     --line-progress: 0%;
 }
 
@@ -118,7 +118,7 @@ h2 {
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 34px; /* vertical line position */
+    left: 26px; /* vertical line position */
     width: 4px;
     background: linear-gradient(to bottom, var(--accent) 0%, var(--accent) var(--line-progress), #ccc var(--line-progress), #ccc 100%);
     z-index: 0;
@@ -134,10 +134,10 @@ h2 {
 .timeline .card::before {
     content: '';
     position: absolute;
-    left: -24px; /* align circle with timeline line */
+    left: -30px; /* align circle with timeline line */
     top: 1.1rem;
-    width: 20px;
-    height: 20px;
+    width: 12px;
+    height: 12px;
     background-color: white;
     border: 4px solid #ccc;
     border-radius: 50%;


### PR DESCRIPTION
## Summary
- reduce timeline circle size further
- reposition line and markers for exact center alignment
- shift the whole timeline 4px left

## Testing
- `npx --version`


------
https://chatgpt.com/codex/tasks/task_e_684d81e69ab0832db01be04f91cd11fa