### PR TITLE
Decrease toggle size for mobile screens

### DIFF
--- a/css/toggle-switch.css
+++ b/css/toggle-switch.css
@@ -60,3 +60,28 @@
     background-color: var(--dark);
     box-shadow: none;
 }
+
+/* Reduce toggle size on small screens */
+@media (max-width: 600px) {
+    .toggle-switch {
+        width: 50px;
+        height: 25px;
+    }
+
+    .switch-label,
+    .slider {
+        height: 25px;
+        border-radius: 12.5px;
+    }
+
+    .slider::before {
+        top: 5px;
+        left: 5px;
+        width: 12.5px;
+        height: 12.5px;
+    }
+
+    .checkbox:checked ~ .slider::before {
+        transform: translateX(25px);
+    }
+}


### PR DESCRIPTION
## Summary
- make the dark mode toggle half the size when the screen width is under 600px

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fe837f55c832d871355016bfc5200