### PR TITLE
Adjust timeline animation speed

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -27,7 +27,7 @@ const animateLine = (target) => {
     if (progressAnimation) cancelAnimationFrame(progressAnimation);
     const start = currentProgress;
     const delta = target - start;
-    const duration = 500; // ms
+    const duration = 1000; // ms - slow down the line animation
     let startTime;
 
     const step = (timestamp) => {
@@ -49,7 +49,11 @@ const updateLineProgress = () => {
     const lineRect = timeline.getBoundingClientRect();
     const viewportBottom = window.scrollY + window.innerHeight;
     const progress = ((viewportBottom - lineRect.top) / lineRect.height) * 100;
-    animateLine(Math.max(0, Math.min(progress, 100)));
+    const target = Math.max(0, Math.min(progress, 100));
+    // Only animate when moving downwards to keep progress visible
+    if (target > currentProgress) {
+        animateLine(target);
+    }
 };
 
 const observer = new IntersectionObserver(entries => {


### PR DESCRIPTION
## Summary
- slow down timeline progress animation to 1 second
- keep line progress from rewinding when scrolling up

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68503cf22680832db0774612ee960279