### PR TITLE
Refactor content loading to use JSON

### DIFF
--- a/content.json
+++ b/content.json
@@ -1,0 +1,126 @@
+{
+  "about": {
+    "text": "As a Development Team Lead with over 7 years of experience, I specialize in backend technologies, primarily PHP. My expertise lies in building robust web applications, integrating third-party systems, and architecting RESTful APIs."
+  },
+  "experience": [
+    {
+      "company": "IPO Solutions",
+      "position": "Development Team Lead",
+      "start": "Feb 2024",
+      "end": "Present",
+      "location": "Bruchsal, Germany",
+      "workType": "Hybrid",
+      "description": "Leading the backend team, overseeing code reviews, architecture, and technical decision-making with a focus on clean and scalable PHP-based systems.",
+      "responsibilities": [
+        "Lead the backend team and oversee code reviews.",
+        "Define architecture and make technical decisions.",
+        "Build clean and scalable PHP systems."
+      ]
+    },
+    {
+      "company": "IPO Solutions",
+      "position": "Senior Software Engineer",
+      "start": "Feb 2022",
+      "end": "Feb 2024",
+      "location": "Weingarten, Germany",
+      "workType": "On-site",
+      "description": "Involved in advanced backend development, system design, and mentoring team members while ensuring high-quality delivery and system integrations.",
+      "responsibilities": [
+        "Develop advanced backend features and systems.",
+        "Design system architecture and integrations.",
+        "Mentor team members and ensure high-quality delivery."
+      ]
+    },
+    {
+      "company": "IPO Solutions",
+      "position": "Software Engineer",
+      "start": "Sep 2021",
+      "end": "Feb 2022",
+      "location": "Weingarten, Germany",
+      "workType": "On-site",
+      "description": "Worked on backend logic, infrastructure management, and implemented modern DevOps practices. Core skills: Laravel, Docker, Kubernetes, AWS, MVC, REST APIs.",
+      "responsibilities": [
+        "Implement backend logic and manage infrastructure.",
+        "Adopt modern DevOps practices.",
+        "Use Laravel, Docker, Kubernetes, AWS and REST APIs."
+      ]
+    },
+    {
+      "company": "IPO Solutions",
+      "position": "Software Engineer",
+      "start": "Aug 2021",
+      "end": "Sep 2021",
+      "location": "Weingarten, Germany",
+      "workType": "Remote",
+      "description": "Focused on refactoring and reviewing JSON-based APIs. Worked in an agile team with a remote-first approach.",
+      "responsibilities": [
+        "Refactor and review JSON-based APIs.",
+        "Collaborate in an agile, remote-first team."
+      ]
+    },
+    {
+      "company": "Freelance",
+      "position": "Backend Developer",
+      "start": "Jan 2021",
+      "end": "Jun 2021",
+      "location": "Remote",
+      "workType": "Remote",
+      "description": "Delivered backend solutions for clients, including API design and integration. Communicated project scope and delivered milestones independently.",
+      "responsibilities": [
+        "Design and integrate APIs for clients.",
+        "Communicate project scope and deliver milestones independently."
+      ]
+    },
+    {
+      "company": "Freelance",
+      "position": "Full Stack Developer",
+      "start": "May 2020",
+      "end": "Sep 2020",
+      "location": "Remote",
+      "workType": "Remote",
+      "description": "Developed full-stack applications and PHP/AWS integrations using design patterns and best practices.",
+      "responsibilities": [
+        "Build full-stack applications.",
+        "Integrate PHP applications with AWS using best practices."
+      ]
+    },
+    {
+      "company": "Plexable",
+      "position": "Senior Software Engineer",
+      "start": "Aug 2019",
+      "end": "Jan 2020",
+      "location": "Amman, Jordan",
+      "workType": "On-site",
+      "description": "Developed and maintained core systems and APIs. Built SDKs, deployed fixes, and handled client support and onboarding. Key tools: Laravel, Docker, AWS.",
+      "responsibilities": [
+        "Develop and maintain core systems and APIs.",
+        "Build SDKs and deploy fixes.",
+        "Provide client support and onboarding."
+      ]
+    },
+    {
+      "company": "Classera",
+      "position": "Software Engineer",
+      "start": "Jul 2016",
+      "end": "Jul 2019",
+      "location": "Amman, Jordan",
+      "workType": "On-site",
+      "description": "Led backend API development, system integration, and payment gateway setups. Coordinated projects and trained junior developers. Used PHP, CakePHP, Laravel.",
+      "responsibilities": [
+        "Lead backend API development and system integration.",
+        "Set up payment gateways.",
+        "Coordinate projects and train junior developers."
+      ]
+    }
+  ],
+  "education": [
+    {
+      "institution": "University of Jordan",
+      "start": "2011",
+      "end": "2015",
+      "field": "Computer Information Systems",
+      "degree": "Bachelor of Science",
+      "location": "Amman, Jordan"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -63,58 +63,13 @@
     <!-- Experience Section -->
     <section>
         <h2>Experience</h2>
-        <div class="timeline">
-            <div class="card">
-                <h3>Development Team Lead – IPO Solutions</h3>
-                <p><strong>Feb 2024 – Present</strong> · Bruchsal, Germany (Hybrid)</p>
-                <p>Leading the backend team, overseeing code reviews, architecture, and technical decision-making with a focus on clean and scalable PHP-based systems.</p>
-            </div>
-            <div class="card">
-                <h3>Senior Software Engineer – IPO Solutions</h3>
-                <p><strong>Feb 2022 – Feb 2024</strong> · Weingarten, Germany (On-site)</p>
-                <p>Involved in advanced backend development, system design, and mentoring team members while ensuring high-quality delivery and system integrations.</p>
-            </div>
-            <div class="card">
-                <h3>Software Engineer – IPO Solutions</h3>
-                <p><strong>Sep 2021 – Feb 2022</strong> · Weingarten, Germany (On-site)</p>
-                <p>Worked on backend logic, infrastructure management, and implemented modern DevOps practices. Core skills: Laravel, Docker, Kubernetes, AWS, MVC, REST APIs.</p>
-            </div>
-            <div class="card">
-                <h3>Software Engineer – IPO Solutions</h3>
-                <p><strong>Aug 2021 – Sep 2021</strong> · Weingarten, Germany (Remote)</p>
-                <p>Focused on refactoring and reviewing JSON-based APIs. Worked in an agile team with a remote-first approach.</p>
-            </div>
-            <div class="card">
-                <h3>Backend Developer – Freelance</h3>
-                <p><strong>Jan 2021 – Jun 2021</strong></p>
-                <p>Delivered backend solutions for clients, including API design and integration. Communicated project scope and delivered milestones independently.</p>
-            </div>
-            <div class="card">
-                <h3>Full Stack Developer – Freelance</h3>
-                <p><strong>May 2020 – Sep 2020</strong></p>
-                <p>Developed full-stack applications and PHP/AWS integrations using design patterns and best practices.</p>
-            </div>
-            <div class="card">
-                <h3>Senior Software Engineer – Plexable</h3>
-                <p><strong>Aug 2019 – Jan 2020</strong> · Amman, Jordan (On-site)</p>
-                <p>Developed and maintained core systems and APIs. Built SDKs, deployed fixes, and handled client support and onboarding. Key tools: Laravel, Docker, AWS.</p>
-            </div>
-            <div class="card">
-                <h3>Software Engineer – Classera</h3>
-                <p><strong>Jul 2016 – Jul 2019</strong> · Amman, Jordan (On-site)</p>
-                <p>Led backend API development, system integration, and payment gateway setups. Coordinated projects and trained junior developers. Used PHP, CakePHP, Laravel.</p>
-            </div>
-        </div>
+        <div class="timeline" id="experience"></div>
     </section>
 
     <!-- Education Section -->
     <section>
         <h2>Education</h2>
-        <div class="card">
-            <h3>University of Jordan</h3>
-            <p><strong>Bachelor of Science in Computer Information Systems</strong></p>
-            <p>2011 – 2015</p>
-        </div>
+        <div id="education"></div>
     </section>
 </main>
 
@@ -138,5 +93,6 @@
 <!-- External JavaScript files -->
 <script src="js/terminal.js"></script>
 <script src="js/main.js"></script>
+<script src="js/content.js"></script>
 </body>
 </html>

--- a/js/content.js
+++ b/js/content.js
@@ -1,0 +1,73 @@
+document.addEventListener('DOMContentLoaded', () => {
+    fetch('content.json')
+        .then(res => res.json())
+        .then(data => {
+            if (data.about && window.setAboutText) {
+                window.setAboutText(data.about.text);
+            }
+
+            const expContainer = document.getElementById('experience');
+            if (expContainer && Array.isArray(data.experience)) {
+                data.experience.forEach(exp => {
+                    const card = document.createElement('div');
+                    card.className = 'card';
+
+                    const h3 = document.createElement('h3');
+                    h3.textContent = `${exp.position} – ${exp.company}`;
+                    card.appendChild(h3);
+
+                    const p1 = document.createElement('p');
+                    const end = exp.end || 'Present';
+                    const work = exp.workType ? ` (${exp.workType})` : '';
+                    const loc = exp.location ? ` · ${exp.location}` : '';
+                    p1.innerHTML = `<strong>${exp.start} – ${end}</strong>${loc}${work}`;
+                    card.appendChild(p1);
+
+                    const p2 = document.createElement('p');
+                    p2.textContent = exp.description;
+                    card.appendChild(p2);
+
+                    if (Array.isArray(exp.responsibilities) && exp.responsibilities.length) {
+                        const ul = document.createElement('ul');
+                        exp.responsibilities.forEach(r => {
+                            const li = document.createElement('li');
+                            li.textContent = r;
+                            ul.appendChild(li);
+                        });
+                        card.appendChild(ul);
+                    }
+
+                    expContainer.appendChild(card);
+                });
+            }
+
+            const eduContainer = document.getElementById('education');
+            if (eduContainer && Array.isArray(data.education)) {
+                data.education.forEach(edu => {
+                    const card = document.createElement('div');
+                    card.className = 'card';
+
+                    const h3 = document.createElement('h3');
+                    h3.textContent = edu.institution;
+                    card.appendChild(h3);
+
+                    const p1 = document.createElement('p');
+                    p1.innerHTML = `<strong>${edu.degree} in ${edu.field}</strong>`;
+                    card.appendChild(p1);
+
+                    const p2 = document.createElement('p');
+                    p2.textContent = `${edu.start} – ${edu.end} · ${edu.location}`;
+                    card.appendChild(p2);
+
+                    eduContainer.appendChild(card);
+                });
+            }
+
+            if (window.initTimeline) {
+                window.initTimeline();
+            }
+        })
+        .catch(err => {
+            console.error('Failed to load content.json', err);
+        });
+});

--- a/js/main.js
+++ b/js/main.js
@@ -17,56 +17,59 @@ toggle.addEventListener('change', () => {
 });
 
 // Timeline scroll animation
-const timeline = document.querySelector('.timeline');
-const cards = document.querySelectorAll('.timeline .card');
+window.initTimeline = function () {
+    const timeline = document.querySelector('.timeline');
+    if (!timeline) return;
+    const cards = document.querySelectorAll('.timeline .card');
 
-let currentProgress = 0;
-let progressAnimation;
+    let currentProgress = 0;
+    let progressAnimation;
 
-const animateLine = (target) => {
-    if (progressAnimation) cancelAnimationFrame(progressAnimation);
-    const start = currentProgress;
-    const delta = target - start;
-    const duration = 1000; // ms - slow down the line animation
-    let startTime;
+    const animateLine = (target) => {
+        if (progressAnimation) cancelAnimationFrame(progressAnimation);
+        const start = currentProgress;
+        const delta = target - start;
+        const duration = 1000; // ms - slow down the line animation
+        let startTime;
 
-    const step = (timestamp) => {
-        if (!startTime) startTime = timestamp;
-        const t = Math.min((timestamp - startTime) / duration, 1);
-        const value = start + delta * t;
-        timeline.style.setProperty('--line-progress', `${value}%`);
-        if (t < 1) {
-            progressAnimation = requestAnimationFrame(step);
-        } else {
-            currentProgress = target;
+        const step = (timestamp) => {
+            if (!startTime) startTime = timestamp;
+            const t = Math.min((timestamp - startTime) / duration, 1);
+            const value = start + delta * t;
+            timeline.style.setProperty('--line-progress', `${value}%`);
+            if (t < 1) {
+                progressAnimation = requestAnimationFrame(step);
+            } else {
+                currentProgress = target;
+            }
+        };
+
+        progressAnimation = requestAnimationFrame(step);
+    };
+
+    const updateLineProgress = () => {
+        const lineRect = timeline.getBoundingClientRect();
+        const viewportBottom = window.scrollY + window.innerHeight;
+        const progress = ((viewportBottom - lineRect.top) / lineRect.height) * 100;
+        const target = Math.max(0, Math.min(progress, 100));
+        // Only animate when moving downwards to keep progress visible
+        if (target > currentProgress) {
+            animateLine(target);
         }
     };
 
-    progressAnimation = requestAnimationFrame(step);
+    const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('active');
+            } else {
+                entry.target.classList.remove('active');
+            }
+        });
+        updateLineProgress();
+    }, { threshold: 0.3 });
+
+    cards.forEach(card => observer.observe(card));
+    window.addEventListener('load', updateLineProgress);
+    window.addEventListener('scroll', updateLineProgress);
 };
-
-const updateLineProgress = () => {
-    const lineRect = timeline.getBoundingClientRect();
-    const viewportBottom = window.scrollY + window.innerHeight;
-    const progress = ((viewportBottom - lineRect.top) / lineRect.height) * 100;
-    const target = Math.max(0, Math.min(progress, 100));
-    // Only animate when moving downwards to keep progress visible
-    if (target > currentProgress) {
-        animateLine(target);
-    }
-};
-
-const observer = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-        if (entry.isIntersecting) {
-            entry.target.classList.add('active');
-        } else {
-            entry.target.classList.remove('active');
-        }
-    });
-    updateLineProgress();
-}, { threshold: 0.3 });
-
-cards.forEach(card => observer.observe(card));
-window.addEventListener('load', updateLineProgress);
-window.addEventListener('scroll', updateLineProgress);

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -3,8 +3,8 @@
  * Description: terminal
  */
 // Typing effect in terminal
-const typedTextEl = document.getElementById("typed-text");
-const aboutText = ` As a Development Team Lead with over 7 years of experience, I specialize in backend technologies, primarily PHP. My expertise lies in building robust web applications, integrating third-party systems, and architecting RESTful APIs.`;
+const typedTextEl = document.getElementById('typed-text');
+let aboutText = '';
 let index = 0;
 const delay = 30;
 
@@ -15,4 +15,9 @@ function typeText() {
     }
 }
 
-window.addEventListener('DOMContentLoaded', typeText);
+window.setAboutText = function(text) {
+    aboutText = text || '';
+    index = 0;
+    typedTextEl.textContent = '';
+    typeText();
+};


### PR DESCRIPTION
## Summary
- extract profile content into `content.json`
- load JSON data via new `content.js`
- update `terminal.js` to allow injecting text from JSON
- refactor timeline logic into `initTimeline` function
- strip static experience and education HTML and render dynamically

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('content.json','utf8')); console.log('ok');" && echo success`

------
https://chatgpt.com/codex/tasks/task_e_6852cc072198832d9dd5a114aaacfdf7