### PR TITLE
Add dynamic skills section

### DIFF
--- a/content.json
+++ b/content.json
@@ -122,5 +122,22 @@
       "degree": "Bachelor of Science",
       "location": "Amman, Jordan"
     }
+  ],
+  "skills": [
+    "PHP",
+    "Laravel",
+    "Laravel Lumen",
+    "JavaScript",
+    "Docker",
+    "Kubernetes",
+    "AWS",
+    "Nginx",
+    "MySQL",
+    "Git",
+    "REST APIs",
+    "HTML",
+    "CSS",
+    "DevOps",
+    "Team Leadership"
   ]
 }

--- a/css/main.css
+++ b/css/main.css
@@ -173,3 +173,28 @@ footer a {
     height: 24px;
     fill: currentColor;
 }
+
+.skills-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.skill-badge {
+    background-color: var(--accent);
+    color: #fff;
+    padding: 0.4rem 0.8rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    transition: transform 0.2s;
+}
+
+.skill-badge:hover {
+    transform: scale(1.1);
+}
+
+.dark .skill-badge {
+    background-color: #333;
+    border: 1px solid var(--accent);
+    color: var(--text-dark);
+}

--- a/index.html
+++ b/index.html
@@ -71,6 +71,11 @@
         <h2>Education</h2>
         <div id="education"></div>
     </section>
+
+    <section>
+        <h2>Skills</h2>
+        <div id="skills" class="skills-list"></div>
+    </section>
 </main>
 
 <!-- Footer -->

--- a/js/content.js
+++ b/js/content.js
@@ -63,6 +63,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
             }
 
+            const skillsContainer = document.getElementById('skills');
+            if (skillsContainer && Array.isArray(data.skills)) {
+                data.skills.forEach(skill => {
+                    const span = document.createElement('span');
+                    span.className = 'skill-badge';
+                    span.textContent = skill;
+                    skillsContainer.appendChild(span);
+                });
+            }
+
             if (window.initTimeline) {
                 window.initTimeline();
             }


### PR DESCRIPTION
## Summary
- add a new `skills` array to `content.json`
- display the skills in the HTML after the education section
- load skills dynamically in JavaScript
- style skill badges

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852d01c75a8832da522a42b20f6cc6f