### PR TITLE
Organize skills in categories

### DIFF
--- a/content.json
+++ b/content.json
@@ -130,62 +130,81 @@
       "location": "Amman, Jordan"
     }
   ],
-  "skills": [
-    "JSON",
-    "Code Review",
-    "ClickUp",
-    "Spoken English",
-    "Design Patterns",
-    "Analytical Skills",
-    "Laravel",
-    "Ubuntu",
-    "CakePHP",
-    "Object-Oriented Programming (OOP)",
-    "Composer",
-    "JavaScript",
-    "Unix",
-    "Docker",
-    "Git",
-    "RESTful Web Services",
-    "MySQL",
-    "Apache",
-    "Amazon Web Services (AWS)",
-    "Linux",
-    "Databases",
-    "PHP",
-    "jQuery",
-    "Nginx",
-    "Redis",
-    "MVC",
-    "Back-End Web Development",
-    "Indexing",
-    "Continuous Integration and Continuous Delivery (CI/CD)",
-    "Cascading Style Sheets (CSS)",
-    "SASS",
-    "SQLite",
-    "HTML",
-    "Algolia",
-    "Jira",
-    "Agile",
-    "Scrum",
-    "Full-Stack Development",
-    "API Development",
-    "Kubernetes",
-    "Rancher Kubernetes Management",
-    "Laravel Lumen",
-    "DigitalOcean",
-    "Workflow Automation",
-    "GitHub Actions",
-    "AWS CDK",
-    "AWS CloudFormation",
-    "AWS EventBridge",
-    "AWS CodeCommit",
-    "AWS ECS",
-    "AWS CodePipeline",
-    "AWS CodeBuild",
-    "Shell scripting",
-    "n8n",
-    "DevOps",
-    "Team Leadership"
-  ]
+  "skills": {
+    "Skills": [
+      "Object-Oriented Programming (OOP)",
+      "Design Patterns",
+      "RESTful Web Services",
+      "API Development",
+      "Back-End Web Development",
+      "Full-Stack Development",
+      "Databases",
+      "Indexing",
+      "Shell scripting",
+      "DevOps",
+      "Workflow Automation",
+      "Code Review",
+      "Analytical Skills",
+      "Team Leadership",
+      "Spoken English"
+    ],
+    "IDEs & Text Editors": [
+      "VS Code",
+      "PhpStorm",
+      "Sublime Text",
+      "Vim"
+    ],
+    "Software Methodologies": [
+      "Agile",
+      "Scrum",
+      "Continuous Integration and Continuous Delivery (CI/CD)"
+    ],
+    "Cloud Providers": [
+      "AWS ECS",
+      "AWS CDK",
+      "AWS CloudFormation",
+      "AWS EventBridge",
+      "AWS CodeCommit",
+      "AWS CodePipeline",
+      "AWS CodeBuild",
+      "DigitalOcean",
+      "Rancher Kubernetes Management"
+    ],
+    "Development Tools & Frameworks": [
+      "Laravel",
+      "Laravel Lumen",
+      "CakePHP",
+      "Composer",
+      "Docker",
+      "Git",
+      "GitHub Actions",
+      "Kubernetes",
+      "n8n"
+    ],
+    "Databases & Search": [
+      "MySQL",
+      "SQLite",
+      "Redis",
+      "Algolia"
+    ],
+    "Web & Front-End Technologies": [
+      "HTML",
+      "Cascading Style Sheets (CSS)",
+      "SASS",
+      "JavaScript",
+      "jQuery",
+      "MVC"
+    ],
+    "Operating Systems & Environments": [
+      "Linux",
+      "Ubuntu",
+      "Unix",
+      "Nginx",
+      "Apache"
+    ],
+    "Project & Task Management": [
+      "ClickUp",
+      "Jira"
+    ]
+  }
 }

--- a/css/main.css
+++ b/css/main.css
@@ -180,6 +180,14 @@ footer a {
     gap: 0.5rem;
 }
 
+.skill-section {
+    margin-bottom: 1rem;
+}
+
+.skill-section h3 {
+    margin-bottom: 0.5rem;
+}
+
 .skill-badge {
     background-color: var(--accent);
     color: #fff;

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 
     <section>
         <h2>Skills</h2>
-        <div id="skills" class="skills-list"></div>
+        <div id="skills"></div>
     </section>
 </main>
 

--- a/js/content.js
+++ b/js/content.js
@@ -64,12 +64,29 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             const skillsContainer = document.getElementById('skills');
-            if (skillsContainer && Array.isArray(data.skills)) {
-                data.skills.forEach(skill => {
-                    const span = document.createElement('span');
-                    span.className = 'skill-badge';
-                    span.textContent = skill;
-                    skillsContainer.appendChild(span);
+            if (skillsContainer && data.skills && typeof data.skills === 'object') {
+                Object.entries(data.skills).forEach(([section, skills]) => {
+                    const sectionDiv = document.createElement('div');
+                    sectionDiv.className = 'skill-section';
+
+                    const h3 = document.createElement('h3');
+                    h3.textContent = section;
+                    sectionDiv.appendChild(h3);
+
+                    const list = document.createElement('div');
+                    list.className = 'skills-list';
+
+                    if (Array.isArray(skills)) {
+                        skills.forEach(skill => {
+                            const span = document.createElement('span');
+                            span.className = 'skill-badge';
+                            span.textContent = skill;
+                            list.appendChild(span);
+                        });
+                    }
+
+                    sectionDiv.appendChild(list);
+                    skillsContainer.appendChild(sectionDiv);
                 });
             }
 


### PR DESCRIPTION
## Summary
- group the skills in `content.json` into named sections
- render the skill categories in the HTML
- style individual skill sections

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855e703f9e4832da2cc99679665c534