### PR TITLE
Fix GitHub activity layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -238,12 +238,28 @@ footer a {
 
 .github-activity table {
     border-collapse: collapse;
+    font-size: 0.75rem;
 }
 
 .github-activity .ContributionCalendar-day {
-    width: 10px;
-    height: 10px;
+    width: 8px;
+    height: 8px;
     border-radius: 2px;
+}
+
+.github-activity .ContributionCalendar-label {
+    font-size: 0.75rem;
+    padding: 0;
+    color: var(--text-light);
+}
+
+.dark .github-activity .ContributionCalendar-label {
+    color: var(--text-dark);
+}
+
+.github-activity .ContributionCalendar-label span[aria-hidden="true"] {
+    position: static !important;
+    clip-path: none !important;
 }
 
 .github-activity .ContributionCalendar-day[data-level="0"] { background-color: #ebedf0; }


### PR DESCRIPTION
## Summary
- shrink GitHub contribution squares
- style contribution labels so month and weekday text is visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68613eeeeec4832d9efce6657380d90a