### PR TITLE
Improve GitHub activity width

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -238,17 +238,19 @@ footer a {
 
 .github-activity table {
     border-collapse: collapse;
-    font-size: 0.75rem;
+    font-size: 0.9rem;
+    width: 100%;
+    table-layout: fixed;
 }
 
 .github-activity .ContributionCalendar-day {
-    width: 8px;
-    height: 8px;
-    border-radius: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
 }
 
 .github-activity .ContributionCalendar-label {
-    font-size: 0.75rem;
+    font-size: 0.85rem;
     padding: 0;
     color: var(--text-light);
 }


### PR DESCRIPTION
## Summary
- enlarge contribution graph cells so the activity calendar fills the page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68614a529228832d9ee9025a3c5c2694