### PR TITLE
Add scheduled GitHub Pages deployment

### DIFF
--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -1,0 +1,33 @@
+name: Scheduled Deploy to GitHub Pages
+
+on:
+  schedule:
+    - cron: '0 0,3,6,9,12,15,18,21 * * *'
+    - cron: '30 1,4,7,10,13,16,19,22 * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Install TypeScript
+        run: npm install -g typescript
+      - name: Compile TypeScript
+        run: tsc
+      - name: Temporarily Modify .gitignore
+        run: sed -i '/dist\//d' .gitignore
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .


### PR DESCRIPTION
## Summary
- add a new workflow that runs every 90 minutes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686268a9c660832d9d91669659688a58