### PR TITLE
Add repository_dispatch trigger

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -6,20 +6,29 @@ on:
     branches: [main]
     types:
       - completed
+  repository_dispatch:
+    types: [pages-deploy]
 
 permissions:
   contents: write
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
+      - name: Checkout code from workflow_run
+        if: github.event_name == 'workflow_run'
         uses: actions/checkout@v3
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
+      - name: Checkout code
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v3
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -14,19 +14,16 @@ permissions:
 
 jobs:
   deploy:
-    if: >-
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success') ||
-      github.event_name == 'repository_dispatch'
+    if: ${{ github.event_name == 'repository_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code from workflow_run
+      - name: Checkout Code
         if: github.event_name == 'workflow_run'
         uses: actions/checkout@v3
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Checkout code
+      - name: Checkout Code
         if: github.event_name == 'repository_dispatch'
         uses: actions/checkout@v3
       - name: Set up Node.js

--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -10,25 +10,13 @@ permissions:
   contents: write
 
 jobs:
-  deploy:
+  dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - name: Trigger pages deploy
+        uses: saedyousef/repository-dispatch@v0.1
         with:
-          node-version: 20
-      - name: Install dependencies
-        run: npm ci
-      - name: Install TypeScript
-        run: npm install -g typescript
-      - name: Compile TypeScript
-        run: tsc
-      - name: Temporarily Modify .gitignore
-        run: sed -i '/dist\//d' .gitignore
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          event_type: pages-deploy


### PR DESCRIPTION
## Summary
- trigger `pages-deploy` dispatch from scheduled workflow
- compile workflow listens for `repository_dispatch` events

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686273e31cd0832db4cc99231d7c97c2