### PR TITLE
Add animated cursor spinner

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -16,7 +16,7 @@ body {
     color: var(--text-light);
     transition: background 0.3s, color 0.3s;
     overflow-x: hidden;
-    cursor: url('../alien-cursor.svg') 16 16, auto;
+    cursor: none;
 }
 
 body.dark {
@@ -292,3 +292,32 @@ footer a {
 .dark .github-activity .ContributionCalendar-day[data-level="2"] { background-color: #006d32; }
 .dark .github-activity .ContributionCalendar-day[data-level="3"] { background-color: #26a641; }
 .dark .github-activity .ContributionCalendar-day[data-level="4"] { background-color: #39d353; }
+
+/* Cursor Spinner */
+#cursor-spinner {
+    position: fixed;
+    width: 16px;
+    height: 16px;
+    pointer-events: none;
+    border-radius: 50%;
+    border: 2px solid #444;
+    box-shadow: -4px -4px 4px #6359f8, 0 -4px 4px 0 #9c32e2, 4px -4px 4px #f36896, 4px 0 4px #ff0b0b, 4px 4px 4px 0 #ff5500, 0 4px 4px 0 #ff9500, -4px 4px 4px 0 #ffb700;
+    animation: cursor-rot 0.7s linear infinite;
+    transform: translate(-50%, -50%);
+    z-index: 1;
+}
+
+#cursor-spinner .cursor-spinner-inner {
+    border: 2px solid #444;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+@keyframes cursor-rot {
+    to { transform: translate(-50%, -50%) rotate(360deg); }
+}

--- a/dist/main.js
+++ b/dist/main.js
@@ -90,10 +90,19 @@ export function initStarButton() {
 export function initMouseHighlight() {
     const highlight = document.createElement('div');
     highlight.id = 'mouse-highlight';
+    const cursor = document.createElement('div');
+    cursor.id = 'cursor-spinner';
+    const inner = document.createElement('div');
+    inner.className = 'cursor-spinner-inner';
+    cursor.appendChild(inner);
     document.body.appendChild(highlight);
+    document.body.appendChild(cursor);
+    document.body.style.cursor = 'none';
     document.addEventListener('mousemove', (e) => {
         highlight.style.left = `${e.clientX}px`;
         highlight.style.top = `${e.clientY}px`;
+        cursor.style.left = `${e.clientX}px`;
+        cursor.style.top = `${e.clientY}px`;
     });
 }
 if (typeof window !== 'undefined') {

--- a/ts/main.ts
+++ b/ts/main.ts
@@ -98,10 +98,19 @@ export function initStarButton(): void {
 export function initMouseHighlight(): void {
     const highlight = document.createElement('div');
     highlight.id = 'mouse-highlight';
+    const cursor = document.createElement('div');
+    cursor.id = 'cursor-spinner';
+    const inner = document.createElement('div');
+    inner.className = 'cursor-spinner-inner';
+    cursor.appendChild(inner);
     document.body.appendChild(highlight);
+    document.body.appendChild(cursor);
+    document.body.style.cursor = 'none';
     document.addEventListener('mousemove', (e: MouseEvent) => {
         highlight.style.left = `${e.clientX}px`;
         highlight.style.top = `${e.clientY}px`;
+        cursor.style.left = `${e.clientX}px`;
+        cursor.style.top = `${e.clientY}px`;
     });
 }
 


### PR DESCRIPTION
## Summary
- hide default mouse cursor and track position
- animate a spinner element that acts as the cursor

## Testing
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864daa4176c832dae0472722084ec42