### PR TITLE
Improve cursor spinner visibility logic

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -87,6 +87,13 @@ export function initStarButton() {
         countEl.textContent = '';
     });
 }
+let cursorSpinner = null;
+export function toggleCursorSpinner(active) {
+    if (!cursorSpinner)
+        return;
+    cursorSpinner.style.display = active ? 'block' : 'none';
+    document.body.style.cursor = active ? 'none' : 'auto';
+}
 export function initMouseHighlight() {
     const highlight = document.createElement('div');
     highlight.id = 'mouse-highlight';
@@ -95,9 +102,11 @@ export function initMouseHighlight() {
     const inner = document.createElement('div');
     inner.className = 'cursor-spinner-inner';
     cursor.appendChild(inner);
+    cursor.style.display = 'none';
+    cursorSpinner = cursor;
     document.body.appendChild(highlight);
     document.body.appendChild(cursor);
-    document.body.style.cursor = 'none';
+    document.body.style.cursor = 'auto';
     document.addEventListener('mousemove', (e) => {
         highlight.style.left = `${e.clientX}px`;
         highlight.style.top = `${e.clientY}px`;

--- a/dist/terminal.js
+++ b/dist/terminal.js
@@ -2,6 +2,7 @@
  * Created by yousef on 6/14/2025 at 3:02 PM
  * Description: terminal
  */
+import { toggleCursorSpinner } from './main';
 // Typing effect in terminal
 function getTypedTextEl() {
     return document.getElementById('typed-text');
@@ -15,12 +16,16 @@ function typeText() {
         typedTextEl.textContent += aboutText.charAt(index++);
         setTimeout(typeText, delay);
     }
+    else {
+        toggleCursorSpinner(false);
+    }
 }
 export function setAboutText(text) {
     aboutText = text || '';
     index = 0;
     const typedTextEl = getTypedTextEl();
     typedTextEl.textContent = '';
+    toggleCursorSpinner(true);
     typeText();
 }
 if (typeof window !== 'undefined') {

--- a/ts/main.ts
+++ b/ts/main.ts
@@ -95,6 +95,14 @@ export function initStarButton(): void {
         });
 }
 
+let cursorSpinner: HTMLElement | null = null;
+
+export function toggleCursorSpinner(active: boolean): void {
+    if (!cursorSpinner) return;
+    cursorSpinner.style.display = active ? 'block' : 'none';
+    document.body.style.cursor = active ? 'none' : 'auto';
+}
+
 export function initMouseHighlight(): void {
     const highlight = document.createElement('div');
     highlight.id = 'mouse-highlight';
@@ -103,9 +111,11 @@ export function initMouseHighlight(): void {
     const inner = document.createElement('div');
     inner.className = 'cursor-spinner-inner';
     cursor.appendChild(inner);
+    cursor.style.display = 'none';
+    cursorSpinner = cursor;
     document.body.appendChild(highlight);
     document.body.appendChild(cursor);
-    document.body.style.cursor = 'none';
+    document.body.style.cursor = 'auto';
     document.addEventListener('mousemove', (e: MouseEvent) => {
         highlight.style.left = `${e.clientX}px`;
         highlight.style.top = `${e.clientY}px`;

--- a/ts/terminal.ts
+++ b/ts/terminal.ts
@@ -2,6 +2,7 @@
  * Created by yousef on 6/14/2025 at 3:02 PM
  * Description: terminal
  */
+import { toggleCursorSpinner } from './main';
 // Typing effect in terminal
 function getTypedTextEl(): HTMLElement {
     return document.getElementById('typed-text') as HTMLElement;
@@ -15,6 +16,8 @@ function typeText(): void {
     if (index < aboutText.length) {
         typedTextEl.textContent += aboutText.charAt(index++);
         setTimeout(typeText, delay);
+    } else {
+        toggleCursorSpinner(false);
     }
 }
 
@@ -23,6 +26,7 @@ export function setAboutText(text: string): void {
     index = 0;
     const typedTextEl = getTypedTextEl();
     typedTextEl.textContent = '';
+    toggleCursorSpinner(true);
     typeText();
 }
 


### PR DESCRIPTION
## Summary
- show the spinner cursor only when text is being typed
- toggle cursor visibility from terminal typing logic

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686541607768832d9e73097affd7cd7e