### PR TITLE
Fix spinner module path

### DIFF
--- a/dist/terminal.js
+++ b/dist/terminal.js
@@ -2,7 +2,7 @@
  * Created by yousef on 6/14/2025 at 3:02 PM
  * Description: terminal
  */
-import { toggleCursorSpinner } from './main';
+import { toggleCursorSpinner } from './main.js';
 // Typing effect in terminal
 function getTypedTextEl() {
     return document.getElementById('typed-text');

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  testMatch: ['**/tests/**/*.test.ts']
+  testMatch: ['**/tests/**/*.test.ts'],
+  moduleNameMapper: {
+    '^\.\/main.js$': '<rootDir>/ts/main.ts'
+  }
 };

--- a/ts/terminal.ts
+++ b/ts/terminal.ts
@@ -2,7 +2,7 @@
  * Created by yousef on 6/14/2025 at 3:02 PM
  * Description: terminal
  */
-import { toggleCursorSpinner } from './main';
+import { toggleCursorSpinner } from './main.js';
 // Typing effect in terminal
 function getTypedTextEl(): HTMLElement {
     return document.getElementById('typed-text') as HTMLElement;


### PR DESCRIPTION
## Summary
- correct module path so the spinner cursor loads in the browser
- map the new path in Jest so tests can still run

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865442a85f8832d94fe788cdabd56a5