### PR TITLE
Add draggable skills container

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -215,7 +215,14 @@ footer a {
     fill: currentColor;
 }
 
+
 .skills-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.skills-container {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
@@ -236,6 +243,10 @@ footer a {
     border-radius: 4px;
     font-size: 0.9rem;
     transition: transform 0.2s;
+}
+
+.skill-badge.dragging {
+    opacity: 0.5;
 }
 
 .skill-badge:hover {

--- a/dist/content.js
+++ b/dist/content.js
@@ -72,27 +72,53 @@ document.addEventListener('DOMContentLoaded', () => {
         if (skillsContainer && data.skills && typeof data.skills === 'object') {
             // Clear previous content in case the script runs more than once
             skillsContainer.innerHTML = '';
-            const fragment = document.createDocumentFragment();
-            Object.entries(data.skills).forEach(([section, skillList]) => {
-                const sectionDiv = document.createElement('div');
-                sectionDiv.className = 'skill-section';
-                const h3 = document.createElement('h3');
-                h3.textContent = section;
-                sectionDiv.appendChild(h3);
-                const list = document.createElement('div');
-                list.className = 'skills-list';
+            const list = document.createElement('div');
+            list.className = 'skills-container';
+            const allSkills = [];
+            Object.values(data.skills).forEach(skillList => {
                 if (Array.isArray(skillList)) {
-                    skillList.forEach(skill => {
-                        const span = document.createElement('span');
-                        span.className = 'skill-badge';
-                        span.textContent = skill;
-                        list.appendChild(span);
-                    });
+                    allSkills.push(...skillList);
                 }
-                sectionDiv.appendChild(list);
-                fragment.appendChild(sectionDiv);
             });
-            skillsContainer.appendChild(fragment);
+            allSkills.forEach(skill => {
+                const span = document.createElement('span');
+                span.className = 'skill-badge';
+                span.textContent = skill;
+                span.draggable = true;
+                list.appendChild(span);
+            });
+            let dragSrc = null;
+            list.addEventListener('dragstart', e => {
+                var _a;
+                const target = e.target;
+                if (target && target.classList.contains('skill-badge')) {
+                    dragSrc = target;
+                    target.classList.add('dragging');
+                    (_a = e.dataTransfer) === null || _a === void 0 ? void 0 : _a.setData('text/plain', '');
+                }
+            });
+            list.addEventListener('dragover', e => {
+                e.preventDefault();
+                const target = e.target.closest('.skill-badge');
+                if (target && dragSrc && target !== dragSrc) {
+                    const nodes = Array.from(list.children);
+                    const srcIndex = nodes.indexOf(dragSrc);
+                    const targetIndex = nodes.indexOf(target);
+                    if (srcIndex < targetIndex) {
+                        list.insertBefore(dragSrc, target.nextSibling);
+                    }
+                    else {
+                        list.insertBefore(dragSrc, target);
+                    }
+                }
+            });
+            list.addEventListener('dragend', () => {
+                if (dragSrc) {
+                    dragSrc.classList.remove('dragging');
+                    dragSrc = null;
+                }
+            });
+            skillsContainer.appendChild(list);
         }
         if (data.terminal) {
             const user = data.terminal.user || '';

--- a/ts/content.ts
+++ b/ts/content.ts
@@ -103,31 +103,59 @@ document.addEventListener('DOMContentLoaded', () => {
             if (skillsContainer && data.skills && typeof data.skills === 'object') {
                 // Clear previous content in case the script runs more than once
                 skillsContainer.innerHTML = '';
-                const fragment = document.createDocumentFragment();
-                Object.entries(data.skills).forEach(([section, skillList]) => {
-                    const sectionDiv = document.createElement('div');
-                    sectionDiv.className = 'skill-section';
 
-                    const h3 = document.createElement('h3');
-                    h3.textContent = section;
-                    sectionDiv.appendChild(h3);
+                const list = document.createElement('div');
+                list.className = 'skills-container';
 
-                    const list = document.createElement('div');
-                    list.className = 'skills-list';
-
+                const allSkills: string[] = [];
+                Object.values(data.skills).forEach(skillList => {
                     if (Array.isArray(skillList)) {
-                        skillList.forEach(skill => {
-                            const span = document.createElement('span');
-                            span.className = 'skill-badge';
-                            span.textContent = skill;
-                            list.appendChild(span);
-                        });
+                        allSkills.push(...skillList);
                     }
-
-                    sectionDiv.appendChild(list);
-                    fragment.appendChild(sectionDiv);
                 });
-                skillsContainer.appendChild(fragment);
+
+                allSkills.forEach(skill => {
+                    const span = document.createElement('span');
+                    span.className = 'skill-badge';
+                    span.textContent = skill;
+                    span.draggable = true;
+                    list.appendChild(span);
+                });
+
+                let dragSrc: HTMLElement | null = null;
+
+                list.addEventListener('dragstart', e => {
+                    const target = e.target as HTMLElement;
+                    if (target && target.classList.contains('skill-badge')) {
+                        dragSrc = target;
+                        target.classList.add('dragging');
+                        e.dataTransfer?.setData('text/plain', '');
+                    }
+                });
+
+                list.addEventListener('dragover', e => {
+                    e.preventDefault();
+                    const target = (e.target as HTMLElement).closest('.skill-badge') as HTMLElement | null;
+                    if (target && dragSrc && target !== dragSrc) {
+                        const nodes = Array.from(list.children);
+                        const srcIndex = nodes.indexOf(dragSrc);
+                        const targetIndex = nodes.indexOf(target);
+                        if (srcIndex < targetIndex) {
+                            list.insertBefore(dragSrc, target.nextSibling);
+                        } else {
+                            list.insertBefore(dragSrc, target);
+                        }
+                    }
+                });
+
+                list.addEventListener('dragend', () => {
+                    if (dragSrc) {
+                        dragSrc.classList.remove('dragging');
+                        dragSrc = null;
+                    }
+                });
+
+                skillsContainer.appendChild(list);
             }
 
             if (data.terminal) {


### PR DESCRIPTION
## Summary
- generate all skill badges in a single container
- allow dragging badges to reorder them
- style new container and dragging state

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686693c7c4dc832db12d629a7a940f7f