### PR TITLE
Improve skill search UX

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -27,7 +27,7 @@
 .input {
   background-color: #010201;
   border: none;
-  width: 301px;
+  width: 400px;
   height: 56px;
   border-radius: 10px;
   color: white;
@@ -45,8 +45,19 @@
 .input:focus {
   outline: none;
 }
+
+.input.active {
+  position: relative;
+  z-index: 1001;
+}
 #main:focus-within > #input-mask {
   display: none;
+}
+
+#search-hint,
+#close-hint {
+  text-align: center;
+  opacity: 0.6;
 }
 #input-mask {
   pointer-events: none;
@@ -304,6 +315,35 @@
   position: absolute;
   left: 20px;
   top: 15px;
+}
+
+.autocomplete-list {
+  list-style: none;
+  margin: 4px 0 0 0;
+  padding: 0;
+  position: absolute;
+  top: 60px;
+  width: 100%;
+  background-color: #010201;
+  border: 1px solid #333;
+  max-height: 180px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.autocomplete-list li {
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.autocomplete-list li:hover {
+  background-color: #222;
+}
+
+.search-results {
+  margin-top: 10px;
+  text-align: center;
+  opacity: 0.8;
 }
 /* highlight style */
 .skill-badge.highlight {

--- a/dist/search.js
+++ b/dist/search.js
@@ -12,14 +12,18 @@ export function initSkillSearch() {
     var _a;
     const wrapper = document.getElementById('search-wrapper');
     const hint = document.getElementById('search-hint');
+    const closeHint = document.getElementById('close-hint');
     const input = document.getElementById('skill-search');
     const datalist = document.getElementById('skill-suggestions');
-    if (!wrapper || !input || !datalist || !hint)
+    const autocomplete = document.getElementById('autocomplete-list');
+    const results = document.getElementById('search-results');
+    let skills = [];
+    if (!wrapper || !input || !datalist || !hint || !autocomplete || !results || !closeHint)
         return;
     fetch('content.json')
         .then(r => r.json())
         .then((data) => {
-        const skills = flattenSkills(data);
+        skills = flattenSkills(data);
         datalist.innerHTML = skills.map(s => `<option value="${s}"></option>`).join('');
     });
     const showSearch = () => {
@@ -27,11 +31,18 @@ export function initSkillSearch() {
         wrapper.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 300, fill: 'forwards' });
         input.focus();
         hint.style.display = 'none';
+        closeHint.style.display = 'block';
+        input.classList.add('active');
+        wrapper.style.zIndex = '1000';
     };
     const hideSearch = () => {
         wrapper.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 300, fill: 'forwards' }).onfinish = () => {
             wrapper.style.display = 'none';
             hint.style.display = '';
+            closeHint.style.display = 'none';
+            input.classList.remove('active');
+            autocomplete.innerHTML = '';
+            wrapper.style.zIndex = '';
         };
     };
     document.addEventListener('keydown', (e) => {
@@ -44,7 +55,25 @@ export function initSkillSearch() {
                 hideSearch();
             }
         }
+        else if (e.key === 'Escape' && wrapper.style.display === 'block') {
+            hideSearch();
+        }
     });
+    const renderSuggestions = (query) => {
+        if (!query) {
+            autocomplete.innerHTML = '';
+            return;
+        }
+        const filtered = skills.filter(s => s.toLowerCase().includes(query.toLowerCase())).slice(0, 6);
+        autocomplete.innerHTML = filtered.map(s => `<li>${s}</li>`).join('');
+        autocomplete.querySelectorAll('li').forEach(li => {
+            li.addEventListener('click', () => {
+                input.value = li.textContent || '';
+                autocomplete.innerHTML = '';
+                input.focus();
+            });
+        });
+    };
     const highlight = (query) => {
         const badges = document.querySelectorAll('.skill-badge');
         badges.forEach(b => {
@@ -58,13 +87,21 @@ export function initSkillSearch() {
         });
     };
     const performSearch = () => {
-        highlight(input.value.trim());
+        const q = input.value.trim();
+        highlight(q);
+        const count = document.querySelectorAll('.skill-badge.highlight').length;
+        results.textContent = count ? `Found ${count} result(s) for "${q}"` : `No results for "${q}"`;
+        results.style.display = 'block';
+        setTimeout(() => {
+            results.style.display = 'none';
+        }, 3000);
     };
     input.addEventListener('keydown', (e) => {
         if (e.key === 'Enter') {
             performSearch();
         }
     });
+    input.addEventListener('input', () => renderSuggestions(input.value));
     (_a = document.getElementById('search-icon')) === null || _a === void 0 ? void 0 : _a.addEventListener('click', performSearch);
 }
 if (typeof window !== 'undefined') {

--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
     <section>
         <h2 id="skills-header"></h2>
         <p id="search-hint">Press <kbd>Ctrl</kbd> + <kbd>K</kbd> to search</p>
+        <p id="close-hint" style="display:none;">Press Esc to close</p>
         <div id="search-wrapper" style="display:none;">
             <!-- From Uiverse.io by Lakshay-art -->
             <div class="grid"></div>
@@ -101,7 +102,7 @@
               <div class="border"></div>
 
               <div id="main">
-                <input id="skill-search" placeholder="Search..." type="text" name="text" class="input" list="skill-suggestions" />
+                <input id="skill-search" placeholder="Search..." type="text" name="text" class="input" />
                 <div id="input-mask"></div>
                 <div id="pink-mask"></div>
                 <div class="filterBorder"></div>
@@ -155,10 +156,12 @@
                     </defs>
                   </svg>
                 </div>
+                <ul id="autocomplete-list" class="autocomplete-list"></ul>
               </div>
             </div>
         </div>
         <datalist id="skill-suggestions"></datalist>
+        <div id="search-results" class="search-results" style="display:none;"></div>
         <div id="skills"></div>
     </section>
 


### PR DESCRIPTION
## Summary
- widen search input and center hints
- display Esc hint when search is open
- show custom autocomplete suggestions and limit to 6 items
- elevate search box on Ctrl+K
- add message for found results

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866a86043f0832d8747fcc90eb842d3