### PR TITLE
Fix about section typing duration

### DIFF
--- a/dist/terminal.js
+++ b/dist/terminal.js
@@ -9,7 +9,7 @@ function getTypedTextEl() {
 }
 let aboutText = '';
 let index = 0;
-const delay = 30;
+let delay = 30;
 function typeText() {
     const typedTextEl = getTypedTextEl();
     if (index < aboutText.length) {
@@ -25,6 +25,7 @@ export function setAboutText(text) {
     index = 0;
     const typedTextEl = getTypedTextEl();
     typedTextEl.textContent = '';
+    delay = aboutText.length ? 2500 / aboutText.length : 0;
     toggleCursorSpinner(true);
     typeText();
 }

--- a/ts/terminal.ts
+++ b/ts/terminal.ts
@@ -9,7 +9,7 @@ function getTypedTextEl(): HTMLElement {
 }
 let aboutText = '';
 let index = 0;
-const delay = 30;
+let delay = 30;
 
 function typeText(): void {
     const typedTextEl = getTypedTextEl();
@@ -26,6 +26,7 @@ export function setAboutText(text: string): void {
     index = 0;
     const typedTextEl = getTypedTextEl();
     typedTextEl.textContent = '';
+    delay = aboutText.length ? 2500 / aboutText.length : 0;
     toggleCursorSpinner(true);
     typeText();
 }


### PR DESCRIPTION
## Summary
- dynamically set terminal typing delay so the About section types within 2.5 seconds
- rebuild JS output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866a91418a8832d8df7c8bba0bc35de