### PR TITLE
Improve skill search behavior

### DIFF
--- a/css/search.css
+++ b/css/search.css
@@ -1,4 +1,9 @@
 /* Search component styles */
+.search-wrapper,
+#search-wrapper {
+  position: relative;
+  z-index: 100;
+}
 .grid {
   height: 800px;
   width: 800px;
@@ -328,7 +333,7 @@
   border: 1px solid #333;
   max-height: 180px;
   overflow-y: auto;
-  z-index: 1000;
+  z-index: 2000;
 }
 
 .autocomplete-list li {
@@ -349,4 +354,12 @@
 .skill-badge.highlight {
   background-color: #ffeb3b;
   color: #000;
+}
+
+@media (max-width: 768px) {
+  #search-wrapper,
+  #search-hint,
+  #close-hint {
+    display: none !important;
+  }
 }

--- a/dist/search.js
+++ b/dist/search.js
@@ -33,7 +33,7 @@ export function initSkillSearch() {
         hint.style.display = 'none';
         closeHint.style.display = 'block';
         input.classList.add('active');
-        wrapper.style.zIndex = '1000';
+        wrapper.style.zIndex = '2000';
     };
     const hideSearch = () => {
         wrapper.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 300, fill: 'forwards' }).onfinish = () => {
@@ -43,6 +43,7 @@ export function initSkillSearch() {
             input.classList.remove('active');
             autocomplete.innerHTML = '';
             wrapper.style.zIndex = '';
+            results.style.display = 'none';
         };
     };
     document.addEventListener('keydown', (e) => {

--- a/ts/search.ts
+++ b/ts/search.ts
@@ -37,7 +37,7 @@ export function initSkillSearch(): void {
     hint.style.display = 'none';
     closeHint.style.display = 'block';
     input.classList.add('active');
-    wrapper.style.zIndex = '1000';
+    wrapper.style.zIndex = '2000';
   };
 
   const hideSearch = () => {
@@ -48,6 +48,7 @@ export function initSkillSearch(): void {
       input.classList.remove('active');
       autocomplete.innerHTML = '';
       wrapper.style.zIndex = '';
+      results.style.display = 'none';
     };
   };
 


### PR DESCRIPTION
## Summary
- improve stacking of search wrapper
- keep footer intact by setting z-index on wrapper
- increase z-index on autocomplete items
- hide search on small displays

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68691ae1065c832d9e4c8714b8a794ca