### PR TITLE
Fix timeline alignment and animation

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -145,11 +145,10 @@ h2 {
 
 .timeline .card {
     position: relative;
-    margin-bottom: 2rem;
+    margin: 0 0 2rem;
     z-index: 1;
-    width: 95%;
-    margin-left: auto;
-    margin-right: auto;
+    width: calc(100% - 40px);
+    margin-left: 0;
 }
 
 #education .card {
@@ -182,7 +181,7 @@ h2 {
 .timeline .card::before {
     content: '';
     position: absolute;
-    left: -29px; /* center circle on the line */
+    left: -30px; /* align circle with timeline */
     top: 1rem;
     width: 12px;
     height: 12px;

--- a/dist/main.js
+++ b/dist/main.js
@@ -52,10 +52,7 @@ export function initTimeline() {
         const viewportBottom = window.scrollY + window.innerHeight;
         const progress = ((viewportBottom - lineRect.top) / lineRect.height) * 100;
         const target = Math.max(0, Math.min(progress, 100));
-        // Only animate when moving downwards to keep progress visible
-        if (target > currentProgress) {
-            animateLine(target);
-        }
+        animateLine(target);
     };
     const observer = new IntersectionObserver(entries => {
         entries.forEach(entry => {

--- a/ts/main.ts
+++ b/ts/main.ts
@@ -58,10 +58,7 @@ export function initTimeline(): void {
         const viewportBottom = window.scrollY + window.innerHeight;
         const progress = ((viewportBottom - lineRect.top) / lineRect.height) * 100;
         const target = Math.max(0, Math.min(progress, 100));
-        // Only animate when moving downwards to keep progress visible
-        if (target > currentProgress) {
-            animateLine(target);
-        }
+        animateLine(target);
     };
 
     const observer = new IntersectionObserver(entries => {


### PR DESCRIPTION
## Summary
- adjust timeline card layout so connectors line up with vertical progress line
- update intersection logic to animate line progress in both directions
- recompile `dist` assets

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686946b0d440832da5bfbf98e6ed6e4f