### PR TITLE
Improve timeline design

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -127,8 +127,8 @@ h2 {
 /* === Timeline Fix === */
 .timeline {
     position: relative;
-    padding-left: 40px;
     --line-progress: 0%;
+    padding: 2rem 0;
 }
 
 .timeline::before {
@@ -136,7 +136,8 @@ h2 {
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 20px; /* vertical line position */
+    left: 50%;
+    transform: translateX(-50%);
     width: 4px;
     background: linear-gradient(to bottom, var(--accent) 0%, var(--accent) var(--line-progress), #ccc var(--line-progress), #ccc 100%);
     z-index: 0;
@@ -145,10 +146,18 @@ h2 {
 
 .timeline .card {
     position: relative;
-    margin: 0 0 2rem;
+    width: 45%;
+    margin: 2rem 0;
     z-index: 1;
-    width: calc(100% - 40px);
-    margin-left: 0;
+}
+
+.timeline .card.left {
+    left: 0;
+    text-align: right;
+}
+
+.timeline .card.right {
+    left: 55%;
 }
 
 #education .card {
@@ -179,9 +188,8 @@ h2 {
 }
 
 .timeline .card::before {
-    content: '';
+    content: "";
     position: absolute;
-    left: -30px; /* align circle with timeline */
     top: 1rem;
     width: 12px;
     height: 12px;
@@ -190,6 +198,14 @@ h2 {
     border-radius: 50%;
     z-index: 2;
     transition: background-color 0.3s, border-color 0.3s;
+}
+
+.timeline .card.left::before {
+    right: -30px;
+}
+
+.timeline .card.right::before {
+    left: -30px;
 }
 
 .timeline .card.active::before {
@@ -360,6 +376,23 @@ footer a {
 .dark .github-activity .ContributionCalendar-day[data-level="2"] { background-color: #006d32; }
 .dark .github-activity .ContributionCalendar-day[data-level="3"] { background-color: #26a641; }
 .dark .github-activity .ContributionCalendar-day[data-level="4"] { background-color: #39d353; }
+
+@media (max-width: 768px) {
+    .timeline::before {
+        left: 20px;
+        transform: none;
+    }
+    .timeline .card {
+        width: calc(100% - 40px);
+        left: 0 !important;
+        text-align: left;
+    }
+    .timeline .card.left::before,
+    .timeline .card.right::before {
+        left: -30px;
+        right: auto;
+    }
+}
 
 /* Cursor Spinner */
 #cursor-spinner {

--- a/dist/content.js
+++ b/dist/content.js
@@ -29,9 +29,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         const expContainer = document.getElementById('experience');
         if (expContainer && Array.isArray(data.experience)) {
-            data.experience.forEach(exp => {
+            data.experience.forEach((exp, i) => {
+                const side = i % 2 === 0 ? 'left' : 'right';
                 const card = document.createElement('div');
-                card.className = 'card';
+                card.className = `card ${side}`;
                 const h3 = document.createElement('h3');
                 h3.textContent = `${exp.position} – ${exp.company}`;
                 card.appendChild(h3);

--- a/ts/content.ts
+++ b/ts/content.ts
@@ -54,9 +54,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const expContainer = document.getElementById('experience');
             if (expContainer && Array.isArray(data.experience)) {
-                data.experience.forEach(exp => {
+                data.experience.forEach((exp, i) => {
+                    const side = i % 2 === 0 ? 'left' : 'right';
                     const card = document.createElement('div');
-                    card.className = 'card';
+                    card.className = `card ${side}`;
 
                     const h3 = document.createElement('h3');
                     h3.textContent = `${exp.position} – ${exp.company}`;


### PR DESCRIPTION
## Summary
- improve timeline layout by alternating cards left and right of the line
- center the timeline line and add responsive styles

## Testing
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694d37f528832da521e9c30ecd8e52